### PR TITLE
chore(release): update package version to 1.4.4

### DIFF
--- a/__tests__/data/common/config/rush/pnpm-lock.yaml
+++ b/__tests__/data/common/config/rush/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-test: 'Fri 26 Nov 2021 07:36:16 AM UTC'
+test: 'Fri 26 Nov 2021 07:54:03 AM UTC'

--- a/__tests__/data/rush.json
+++ b/__tests__/data/rush.json
@@ -1,1 +1,1 @@
-{ "test": "Fri 26 Nov 2021 07:36:16 AM UTC" }
+{ "test": "Fri 26 Nov 2021 07:54:03 AM UTC" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@advancedcsg/actions-rush-helper",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "description": "GitHub Action RushJS helper",
   "main": "src/main.js",
   "scripts": {


### PR DESCRIPTION
- fix: run `rush build` only when build param is `true`
- chore: update outdated dev dependencies (including build tool ncc)
