### PR TITLE
fix(workflows): set-output depricated replaced with environment files

### DIFF
--- a/.github/workflows/branch-tests.yml
+++ b/.github/workflows/branch-tests.yml
@@ -26,8 +26,7 @@ jobs:
           run_install: false
       - name: Determine pnpm cache directory
         id: pnpm-cache
-        run: |
-          echo "::set-output name=dir::$(pnpm config get cache)"
+        run: echo "dir=$(pnpm config get cache)" >> $GITHUB_OUTPUT
       - name: Restore npm cache
         uses: actions/cache@v3.0.11
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,7 @@ jobs:
           node-version: '16.x'
       - name: Determine npm cache directory
         id: npm-cache
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+        run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - name: Restore npm cache
         uses: actions/cache@v3.0.11
         with:

--- a/__tests__/data/common/config/rush/pnpm-lock.yaml
+++ b/__tests__/data/common/config/rush/pnpm-lock.yaml
@@ -1,1 +1,1 @@
-test: 'Mon 22 Aug 2022 09:47:34 BST'
+test: 'Tue 29 Nov 2022 14:31:37 GMT'

--- a/__tests__/data/rush.json
+++ b/__tests__/data/rush.json
@@ -1,1 +1,1 @@
-{ "test": "Mon 22 Aug 2022 09:47:34 BST" }
+{ "test": "Tue 29 Nov 2022 14:31:37 GMT" }


### PR DESCRIPTION
see
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/